### PR TITLE
Create a script that updates the runner to the latest version

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -2,7 +2,6 @@ FROM ghcr.io/onezerocompany/base as build
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG RUNNER_VERSION=2.319.1
 ARG RUNNER_CONTAINER_HOOKS_VERSION=0.6.1
 ARG DOCKER_VERSION=27.1.1
 ARG BUILDX_VERSION=0.16.2
@@ -10,9 +9,14 @@ ARG BUILDX_VERSION=0.16.2
 USER root
 
 WORKDIR /actions-runner
+
+# Fetch the latest runner version
+COPY update-runner.sh /actions-runner/update-runner.sh
+RUN chmod +x /actions-runner/update-runner.sh && /actions-runner/update-runner.sh
+
 RUN export RUNNER_ARCH=${TARGETARCH} \
     && if [ "$RUNNER_ARCH" = "amd64" ]; then export RUNNER_ARCH=x64 ; fi \
-    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-${TARGETOS}-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz \
+    && curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/download/v$(cat /actions-runner/latest-runner-version)/actions-runner-${TARGETOS}-${RUNNER_ARCH}-$(cat /actions-runner/latest-runner-version).tar.gz \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz
 

--- a/images/runner/update-runner.sh
+++ b/images/runner/update-runner.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Fetch the latest runner version from GitHub releases
+latest_version=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name' | cut -c 2-)
+
+# Save the fetched version to a file for use in the Dockerfile
+echo $latest_version > /actions-runner/latest-runner-version


### PR DESCRIPTION
Related to #1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/onezerocompany/devcontainers/issues/1?shareId=d51996e7-64c5-485e-a968-3ef89577c73f).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dynamic mechanism to fetch the latest version of the GitHub Actions runner, ensuring users always have access to the most recent updates.
	- Added a new script to automate the retrieval of the latest runner version from the GitHub API.

- **Bug Fixes**
	- Removed hardcoded runner version to prevent outdated installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->