### PR TITLE
Fix permission denied error for /home/zero in runner image

### DIFF
--- a/images/runner/Dockerfile
+++ b/images/runner/Dockerfile
@@ -60,7 +60,8 @@ RUN adduser --disabled-password --gecos "" --uid 1001 runner \
     && if [ -f /home/zero/.mise.toml ]; then cp /home/zero/.mise.toml /home/runner/.mise.toml; fi \
     && if [ -f /home/zero/.config/starship.toml ]; then cp /home/zero/.config/starship.toml /home/runner/.config/starship.toml; fi \
     && chown -R runner:runner /home/runner \
-    && if [ -f /home/runner/.local/bin/mise ]; then chmod +x /home/runner/.local/bin/mise; fi
+    && if [ -f /home/runner/.local/bin/mise ]; then chmod +x /home/runner/.local/bin/mise; fi \
+    && chmod -R 777 /home/zero
 
 # Set up mise environment variables for runner user
 ENV MISE_CACHE_DIR=/home/runner/.cache/mise


### PR DESCRIPTION
## Summary
- Fixed EACCES permission denied errors in GitHub Actions workflows when setup actions try to write to `/home/zero`
- Added `chmod -R 777 /home/zero` to the runner Dockerfile to grant full permissions

## Problem
GitHub Actions workflows using the runner image were failing when setup actions (like `setup-bun`) attempted to create directories in `/home/zero`. The runner user (UID 1001) didn't have write access to the `/home/zero` directory which is owned by the zero user (UID 1000) from the base image.

Example error from ellie-languages/create-your-own-workbook:
```
Error: EACCES: permission denied, mkdir '/home/zero/.bun/bin'
```

## Solution
Grant full permissions (777) to the `/home/zero` directory so the runner user and all GitHub Actions processes can write to it when installing tools and dependencies.

## Test plan
- [ ] Verify the runner image builds successfully with the changes
- [ ] Test that the ellie-languages/create-your-own-workbook Claude Code workflow no longer encounters permission errors
- [ ] Confirm setup actions (setup-bun, etc.) can successfully install to `/home/zero`

🤖 Generated with [Claude Code](https://claude.com/claude-code)